### PR TITLE
Add collection 2021-1.2 config

### DIFF
--- a/collection-2021-1.2.yml
+++ b/collection-2021-1.2.yml
@@ -1,0 +1,76 @@
+jobs:
+- job: run_profile_collection_2021_1_2
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  displayName: "${{ parameters.beamline_acronym }}:"
+
+  variables:
+    - template: .azure-templates/common-vars.yml
+    - name: BEAMLINE_ACRONYM
+      value: ${{ parameters.beamline_acronym }}
+    - name: CAPROTO_COMMAND
+      value: "python -m caproto.ioc_examples.pathological.spoof_beamline"
+    - name: CONDA_ENV_NAME
+      value: collection-2021-1.2
+    # DOI: https://doi.org/10.5281/zenodo.4421838
+    # URL: https://zenodo.org/record/4421838/files/collection-2021-1.2.tar.gz?download=1
+    - name: ZENODO_ID
+      value: 4421838
+    - name: MD5_CHECKSUM
+      value: b1bd9cf6660cc7527ec708f60e396813
+
+  strategy:
+    matrix:
+      collection_2021_1_2:
+        OPHYD_CONTROL_LAYER: pyepics
+        CONDA_CHANNEL_NAME: nsls2forge
+        PYTHON_VERSION: 3.7
+      # Commenting out caproto OPHYD_CONTROL_LAYER test due to
+      # https://github.com/caproto/caproto/issues/696.
+      # py37_caproto:
+      #   OPHYD_CONTROL_LAYER: caproto
+      #   CONDA_CHANNEL_NAME: nsls2forge
+      #   PYTHON_VERSION: 3.7
+
+  steps:
+
+    # Check the env
+    - template: .azure-templates/check-env.yml
+
+    # TODO: uncomment the block below once all profile repos are
+    # "profile_collection". Some of them are not compliant with the name and
+    # single profile per repo approach. See the list of those below.
+    # # Check the startup/ dir exists
+    # - template: .azure-templates/check-startup-dir-exists.yml
+
+    # Get pyOlog and databroker configs
+    - template: .azure-templates/get-configs.yml
+
+    # Prepare a test profile dir
+    - template: .azure-templates/prepare-test-profile-dir.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
+
+    # Start mongodb service
+    - template: .azure-templates/start-mongo.yml
+
+    # Start docker service
+    # - template: .azure-templates/start-docker.yml
+
+    # Download and install miniconda
+    - template: .azure-templates/install-miniconda.yml
+
+    # Create conda env
+    - template: .azure-templates/create-conda-env-archive.yml
+
+    # Perform beamline-specific actions
+    - template: .azure-templates/bl-specific.yml
+
+    # Start caproto IOC and start IPython with startup files
+    - template: .azure-templates/run-tests.yml
+
+    # Display bluesky logs
+    - template: .azure-templates/display-bluesky-logs.yml


### PR DESCRIPTION
This config is for the `collection-2021-1.2` conda environment released at https://doi.org/10.5281/zenodo.4421838.

```diff
$ diff collection-2021-1.0.yml collection-2021-1.2.yml
2c2
< - job: run_profile_collection_2021_1_0
---
> - job: run_profile_collection_2021_1_2
16,18c16,18
<       value: collection-2021-1.0
<     # DOI: https://doi.org/10.5281/zenodo.4421721
<     # URL: https://zenodo.org/record/4421721/files/collection-2021-1.0.tar.gz?download=1
---
>       value: collection-2021-1.2
>     # DOI: https://doi.org/10.5281/zenodo.4421838
>     # URL: https://zenodo.org/record/4421838/files/collection-2021-1.2.tar.gz?download=1
20c20
<       value: 4421721
---
>       value: 4421838
22c22
<       value: 12fa67ad0ed60bc7eeac8a2765109ab4
---
>       value: b1bd9cf6660cc7527ec708f60e396813
26c26
<       collection_2021_1_0:
---
>       collection_2021_1_2:
```