### PR TITLE
Install redis package and start it

### DIFF
--- a/.azure-templates/install-system-packages.yml
+++ b/.azure-templates/install-system-packages.yml
@@ -3,6 +3,7 @@ steps:
   - script: |
       sudo apt-get clean
       sudo apt-get update
-      sudo apt-get install xvfb
+      # sudo apt-get install xvfb
+      sudo apt-get install redis
     displayName: "* install required packages"
     condition: succeeded()

--- a/.azure-templates/start-redis.yml
+++ b/.azure-templates/start-redis.yml
@@ -1,0 +1,6 @@
+# Start redis service
+steps:
+  - script: |
+      sudo systemctl start redis && sudo systemctl status redis
+    displayName: "* start redis service"
+    condition: succeeded()

--- a/collection-2021-1.0.yml
+++ b/collection-2021-1.0.yml
@@ -54,9 +54,6 @@ jobs:
     # Install system packages
     - template: .azure-templates/install-system-packages.yml
 
-    # Check services and system packages
-    - template: .azure-templates/check-services-and-pkgs.yml
-
     # Start mongodb service
     - template: .azure-templates/start-mongo.yml
 

--- a/collection-2021-1.0.yml
+++ b/collection-2021-1.0.yml
@@ -51,14 +51,23 @@ jobs:
     # Prepare a test profile dir
     - template: .azure-templates/prepare-test-profile-dir.yml
 
+    # Install system packages
+    - template: .azure-templates/install-system-packages.yml
+
     # Check services and system packages
     - template: .azure-templates/check-services-and-pkgs.yml
 
     # Start mongodb service
     - template: .azure-templates/start-mongo.yml
 
+    # Start redis service
+    - template: .azure-templates/start-redis.yml
+
     # Start docker service
     # - template: .azure-templates/start-docker.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
 
     # Download and install miniconda
     - template: .azure-templates/install-miniconda.yml

--- a/collection-2021-1.2.yml
+++ b/collection-2021-1.2.yml
@@ -54,9 +54,6 @@ jobs:
     # Install system packages
     - template: .azure-templates/install-system-packages.yml
 
-    # Check services and system packages
-    - template: .azure-templates/check-services-and-pkgs.yml
-
     # Start mongodb service
     - template: .azure-templates/start-mongo.yml
 

--- a/collection-2021-1.2.yml
+++ b/collection-2021-1.2.yml
@@ -51,14 +51,23 @@ jobs:
     # Prepare a test profile dir
     - template: .azure-templates/prepare-test-profile-dir.yml
 
+    # Install system packages
+    - template: .azure-templates/install-system-packages.yml
+
     # Check services and system packages
     - template: .azure-templates/check-services-and-pkgs.yml
 
     # Start mongodb service
     - template: .azure-templates/start-mongo.yml
 
+    # Start redis service
+    - template: .azure-templates/start-redis.yml
+
     # Start docker service
     # - template: .azure-templates/start-docker.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
 
     # Download and install miniconda
     - template: .azure-templates/install-miniconda.yml


### PR DESCRIPTION
This is an optional update to use in the future. Right now, only BMM is in need of that package (see https://github.com/NSLS-II-BMM/profile_collection/pull/11, where we install it via `bl-specific.sh`).