### PR TITLE
Add expandable groups to the output

### DIFF
--- a/.azure-templates/run-tests.yml
+++ b/.azure-templates/run-tests.yml
@@ -7,14 +7,16 @@ steps:
       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
       export DISPLAY=:99
 
-      echo "##[group]Packages and env info"
       # Activate the test env and display some relevant info:
       source $HOME/miniconda/etc/profile.d/conda.sh  # this makes all conda vars available
       conda activate ${CONDA_ENV_NAME}
+      echo "##[group]Conda env info"
       conda env list
       conda info
       conda list
+      echo "##[endgroup]"
 
+      echo "##[group]Environment variables"
       env | sort -u
       echo "##[endgroup]"
 
@@ -57,7 +59,9 @@ steps:
           print(f'Executing {f} in CI')
           ip.parent._exec_file(f)"
 
+      echo "##[group]Command to use"
       echo "$command"
+      echo "##[endgroup]"
 
       # TODO: remove the condition below once all repos are compliant.
       # This is a temporary step, and is needed for the non-compliant BL

--- a/.azure-templates/run-tests.yml
+++ b/.azure-templates/run-tests.yml
@@ -7,6 +7,7 @@ steps:
       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
       export DISPLAY=:99
 
+      echo "##[group]Packages and env info"
       # Activate the test env and display some relevant info:
       source $HOME/miniconda/etc/profile.d/conda.sh  # this makes all conda vars available
       conda activate ${CONDA_ENV_NAME}
@@ -15,6 +16,7 @@ steps:
       conda list
 
       env | sort -u
+      echo "##[endgroup]"
 
       if [ ! -z "${USE_EPICS_IOC}" -a "${USE_EPICS_IOC}" == "1" ]; then
           echo "Not using caproto-spoof-beamline IOC as instructed by .ci/bl-specific.sh"


### PR DESCRIPTION
Added the expandable groups based on the [Azure Pipelines documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#formatting-commands) and [`conda-smithy` templates](https://github.com/conda-forge/conda-smithy/blob/master/conda_smithy/feedstock_content/.scripts/logging_utils.sh). That will make reading of the test logs much easier, so users won't have to scroll through hundreds of lines.

A successful run is [here](https://dev.azure.com/nsls2/profile_collections/_build/results?buildId=2602&view=logs&j=f49b15f4-5265-534f-a4f1-44752c378f34&t=32570ddb-4bf8-581a-feda-5bc0a41d323f):
![image](https://user-images.githubusercontent.com/13209176/131888424-5badbb2a-c300-4a79-bf71-f6cc683f5e0b.png)
