### PR TITLE
2024-2.3 configs

### DIFF
--- a/2024-2.3-py310-tiled.yml
+++ b/2024-2.3-py310-tiled.yml
@@ -1,0 +1,82 @@
+jobs:
+- job: run_profile_collection_2024_2_3_py310_tiled
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  displayName: "${{ parameters.beamline_acronym }}:"
+
+  variables:
+    - template: .azure-templates/common-vars.yml
+    - name: BEAMLINE_ACRONYM
+      value: ${{ parameters.beamline_acronym }}
+    - name: CAPROTO_COMMAND
+      value: "python -m caproto.ioc_examples.pathological.spoof_beamline"
+    - name: CONDA_ENV_NAME
+      value: 2024-2.3-py310-tiled
+    # DOI: https://doi.org/10.5281/zenodo.13156180
+    # URL: https://zenodo.org/record/13156180/files/2024-2.3-py310-tiled.tar.gz?download=1
+    - name: ZENODO_ID
+      value: 13156180
+    - name: MD5_CHECKSUM
+      value: 79656303d3dd342c2efa86b7b58965ff
+
+  strategy:
+    matrix:
+      2024_2_3_py310_tiled:
+        OPHYD_CONTROL_LAYER: pyepics
+        CONDA_CHANNEL_NAME: conda-forge
+        PYTHON_VERSION: 3.10
+      # Commenting out caproto OPHYD_CONTROL_LAYER test due to
+      # https://github.com/caproto/caproto/issues/696.
+      # py37_caproto:
+      #   OPHYD_CONTROL_LAYER: caproto
+      #   CONDA_CHANNEL_NAME: nsls2forge
+      #   PYTHON_VERSION: 3.7
+
+  steps:
+
+    # Check the env
+    - template: .azure-templates/check-env.yml
+
+    # TODO: uncomment the block below once all profile repos are
+    # "profile_collection". Some of them are not compliant with the name and
+    # single profile per repo approach. See the list of those below.
+    # # Check the startup/ dir exists
+    # - template: .azure-templates/check-startup-dir-exists.yml
+
+    # Get pyOlog and databroker configs
+    - template: .azure-templates/get-configs.yml
+
+    # Prepare a test profile dir
+    - template: .azure-templates/prepare-test-profile-dir.yml
+
+    # Install system packages
+    - template: .azure-templates/install-system-packages.yml
+
+    # Start mongodb service
+    - template: .azure-templates/start-mongo.yml
+
+    # Start redis service
+    - template: .azure-templates/start-redis.yml
+
+    # Start docker service
+    # - template: .azure-templates/start-docker.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
+
+    # Download and install miniconda
+    - template: .azure-templates/install-miniconda.yml
+
+    # Create conda env
+    - template: .azure-templates/create-conda-env-archive.yml
+
+    # Perform beamline-specific actions
+    - template: .azure-templates/bl-specific.yml
+
+    # Start caproto IOC and start IPython with startup files
+    - template: .azure-templates/run-tests.yml
+
+    # Display bluesky logs
+    - template: .azure-templates/display-bluesky-logs.yml

--- a/2024-2.3-py311-tiled.yml
+++ b/2024-2.3-py311-tiled.yml
@@ -1,0 +1,82 @@
+jobs:
+- job: run_profile_collection_2024_2_3_py311_tiled
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  displayName: "${{ parameters.beamline_acronym }}:"
+
+  variables:
+    - template: .azure-templates/common-vars.yml
+    - name: BEAMLINE_ACRONYM
+      value: ${{ parameters.beamline_acronym }}
+    - name: CAPROTO_COMMAND
+      value: "python -m caproto.ioc_examples.pathological.spoof_beamline"
+    - name: CONDA_ENV_NAME
+      value: 2024-2.3-py311-tiled
+    # DOI: https://doi.org/10.5281/zenodo.13156180
+    # URL: https://zenodo.org/record/13156180/files/2024-2.3-py311-tiled.tar.gz?download=1
+    - name: ZENODO_ID
+      value: 13156180
+    - name: MD5_CHECKSUM
+      value: f25aeedc683711cbf7ed16da725e7812
+
+  strategy:
+    matrix:
+      2024_2_3_py311_tiled:
+        OPHYD_CONTROL_LAYER: pyepics
+        CONDA_CHANNEL_NAME: conda-forge
+        PYTHON_VERSION: 3.11
+      # Commenting out caproto OPHYD_CONTROL_LAYER test due to
+      # https://github.com/caproto/caproto/issues/696.
+      # py37_caproto:
+      #   OPHYD_CONTROL_LAYER: caproto
+      #   CONDA_CHANNEL_NAME: nsls2forge
+      #   PYTHON_VERSION: 3.7
+
+  steps:
+
+    # Check the env
+    - template: .azure-templates/check-env.yml
+
+    # TODO: uncomment the block below once all profile repos are
+    # "profile_collection". Some of them are not compliant with the name and
+    # single profile per repo approach. See the list of those below.
+    # # Check the startup/ dir exists
+    # - template: .azure-templates/check-startup-dir-exists.yml
+
+    # Get pyOlog and databroker configs
+    - template: .azure-templates/get-configs.yml
+
+    # Prepare a test profile dir
+    - template: .azure-templates/prepare-test-profile-dir.yml
+
+    # Install system packages
+    - template: .azure-templates/install-system-packages.yml
+
+    # Start mongodb service
+    - template: .azure-templates/start-mongo.yml
+
+    # Start redis service
+    - template: .azure-templates/start-redis.yml
+
+    # Start docker service
+    # - template: .azure-templates/start-docker.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
+
+    # Download and install miniconda
+    - template: .azure-templates/install-miniconda.yml
+
+    # Create conda env
+    - template: .azure-templates/create-conda-env-archive.yml
+
+    # Perform beamline-specific actions
+    - template: .azure-templates/bl-specific.yml
+
+    # Start caproto IOC and start IPython with startup files
+    - template: .azure-templates/run-tests.yml
+
+    # Display bluesky logs
+    - template: .azure-templates/display-bluesky-logs.yml

--- a/2024-2.3-py312-tiled.yml
+++ b/2024-2.3-py312-tiled.yml
@@ -1,0 +1,82 @@
+jobs:
+- job: run_profile_collection_2024_2_3_py312_tiled
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  displayName: "${{ parameters.beamline_acronym }}:"
+
+  variables:
+    - template: .azure-templates/common-vars.yml
+    - name: BEAMLINE_ACRONYM
+      value: ${{ parameters.beamline_acronym }}
+    - name: CAPROTO_COMMAND
+      value: "python -m caproto.ioc_examples.pathological.spoof_beamline"
+    - name: CONDA_ENV_NAME
+      value: 2024-2.3-py312-tiled
+    # DOI: https://doi.org/10.5281/zenodo.13156180
+    # URL: https://zenodo.org/record/13156180/files/2024-2.3-py312-tiled.tar.gz?download=1
+    - name: ZENODO_ID
+      value: 13156180
+    - name: MD5_CHECKSUM
+      value: a73f3c3c2636b4b964f19f1fe2b8c7ed
+
+  strategy:
+    matrix:
+      2024_2_3_py312_tiled:
+        OPHYD_CONTROL_LAYER: pyepics
+        CONDA_CHANNEL_NAME: conda-forge
+        PYTHON_VERSION: 3.12
+      # Commenting out caproto OPHYD_CONTROL_LAYER test due to
+      # https://github.com/caproto/caproto/issues/696.
+      # py37_caproto:
+      #   OPHYD_CONTROL_LAYER: caproto
+      #   CONDA_CHANNEL_NAME: nsls2forge
+      #   PYTHON_VERSION: 3.7
+
+  steps:
+
+    # Check the env
+    - template: .azure-templates/check-env.yml
+
+    # TODO: uncomment the block below once all profile repos are
+    # "profile_collection". Some of them are not compliant with the name and
+    # single profile per repo approach. See the list of those below.
+    # # Check the startup/ dir exists
+    # - template: .azure-templates/check-startup-dir-exists.yml
+
+    # Get pyOlog and databroker configs
+    - template: .azure-templates/get-configs.yml
+
+    # Prepare a test profile dir
+    - template: .azure-templates/prepare-test-profile-dir.yml
+
+    # Install system packages
+    - template: .azure-templates/install-system-packages.yml
+
+    # Start mongodb service
+    - template: .azure-templates/start-mongo.yml
+
+    # Start redis service
+    - template: .azure-templates/start-redis.yml
+
+    # Start docker service
+    # - template: .azure-templates/start-docker.yml
+
+    # Check services and system packages
+    - template: .azure-templates/check-services-and-pkgs.yml
+
+    # Download and install miniconda
+    - template: .azure-templates/install-miniconda.yml
+
+    # Create conda env
+    - template: .azure-templates/create-conda-env-archive.yml
+
+    # Perform beamline-specific actions
+    - template: .azure-templates/bl-specific.yml
+
+    # Start caproto IOC and start IPython with startup files
+    - template: .azure-templates/run-tests.yml
+
+    # Display bluesky logs
+    - template: .azure-templates/display-bluesky-logs.yml


### PR DESCRIPTION
Adding new configuration files for Python 3.10, 3.11, and 3.12 to use the conda envs uploaded to https://zenodo.org/records/13156180.

Generated via:
```bash
$ <create/activate a conda env with pyzenodo3>
$ git clone https://github.com/nsls2-conda-envs/conda-pack-template
$ git clone https://github.com/nsls2-conda-envs/nsls2-collection-tiled
$ cd conda-pack-template/

$ python render.py -c ../nsls2-collection-tiled/configs/config-py310.yml -z 13156180 -f nsls2-collection-profile-collection-ci.yml.j2
2024-2.3-py310-tiled.yml

$ python render.py -c ../nsls2-collection-tiled/configs/config-py311.yml -z 13156180 -f nsls2-collection-profile-collection-ci.yml.j2
2024-2.3-py311-tiled.yml

$ python render.py -c ../nsls2-collection-tiled/configs/config-py312.yml -z 13156180 -f nsls2-collection-profile-collection-ci.yml.j2
2024-2.3-py312-tiled.yml
```